### PR TITLE
Remove unused SP Worker permissions

### DIFF
--- a/installer/k8s-artefacts/observability/sp/sp-worker.yaml
+++ b/installer/k8s-artefacts/observability/sp/sp-worker.yaml
@@ -84,7 +84,7 @@ spec:
           periodSeconds: 10
       imagePullSecrets:
       - name: wso2creds
-      serviceAccountName: "cellery-stream-processor"
+      serviceAccountName: "cellerysvc-account"
       volumes:
       - name: sp-worker-conf
         configMap:
@@ -92,37 +92,6 @@ spec:
       - name: sp-worker-siddhi
         configMap:
           name: sp-worker-siddhi
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: cellery-stream-processor
-  namespace: cellery-system
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: cellery-stream-processor
-rules:
-  - apiGroups:
-      - ""
-    resources:
-      - namespaces
-    verbs:
-      - list
----
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRoleBinding
-metadata:
-  name: cellery-stream-processor-binding
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cellery-stream-processor
-subjects:
-  - kind: ServiceAccount
-    name: cellery-stream-processor
-    namespace: cellery-system
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
## Purpose
> Remove unused SP Worker permissions.

## Goals
> Remove unused SP Worker permissions. Since the Cellery Local Auth Provider does not need to list namespaces now (wso2/cellery-observability#108), this can be removed

## Approach
> Remove unused SP Worker permissions.

## User stories
> Summary of user stories addressed by this change>

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> wso2/cellery-observability#108

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A